### PR TITLE
CompatHelper: add new compat entry for DSP at version 0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 LBFGSB = "5be7bae1-8223-5378-bac3-9e7378a2f6e6"
 
 [compat]
+DSP = "0.7"
 julia = "1.6.7"
 
 [extras]


### PR DESCRIPTION
(keep existing compat)