### PR TITLE
CompatHelper

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ LBFGSB = "5be7bae1-8223-5378-bac3-9e7378a2f6e6"
 
 [compat]
 DSP = "0.7"
+DocStringExtensions = "0.9"
 LBFGSB = "0.4"
 julia = "1.6.7"
 


### PR DESCRIPTION
add new compat entry for DocStringExtensions at version 0.9, (keep existing compat)